### PR TITLE
node-red-contrib-home-assistant-websocket

### DIFF
--- a/node-red/Dockerfile
+++ b/node-red/Dockerfile
@@ -14,7 +14,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Setup base
 RUN \
     apk add --no-cache --virtual .build-dependencies \
-        gcc=6.4.0-r8 \
+        gcc=6.4.0-r9 \
         libc-dev=0.7.1-r0 \
         python2-dev=2.7.15-r1 \
         py2-pip=10.0.1-r0 \

--- a/node-red/Dockerfile
+++ b/node-red/Dockerfile
@@ -37,7 +37,7 @@ RUN \
     \
     && npm cache clear --force \
     \
-    && apk del --purge .build-dependencies
+    && apk del --purge --force-broken-world .build-dependencies
 
 # Copy root filesystem
 COPY rootfs /

--- a/node-red/Dockerfile
+++ b/node-red/Dockerfile
@@ -21,8 +21,8 @@ RUN \
     \
     && apk add --no-cache \
         git=2.18.0-r0 \
-        nodejs=8.11.4-r0 \
-        npm=8.11.4-r0 \
+        nodejs@edge=8.12.0-r0 \
+        npm@edge=8.12.0-r0 \
         paxctl=0.9-r0 \
         python2=2.7.15-r1 \
     \

--- a/node-red/package.json
+++ b/node-red/package.json
@@ -18,7 +18,7 @@
         "node-red-contrib-change-detect": "0.2.0",
         "node-red-contrib-counter": "0.1.5",
         "node-red-contrib-google-home-notify": "0.0.6",
-        "node-red-contrib-home-assistant": "0.3.2",
+        "node-red-contrib-home-assistant-websocket": "0.1.0",
         "node-red-contrib-http-request": "0.1.13",
         "node-red-contrib-influxdb": "0.2.2",
         "node-red-contrib-interval-length": "0.0.2",


### PR DESCRIPTION
# Proposed Changes

The original Home Assistant node is unmaintained and there are currently 2 forks active.
I believe that the websockets version has the future. Because of the technology, the quality delivered in this short time span AND the skills of the maintainer.

node-red-contrib-home-assistant-websocket

## Related Issues

n/a