### PR TITLE
:sparkles: Adds HA Authentication to Node-RED

### DIFF
--- a/node-red/config.json
+++ b/node-red/config.json
@@ -17,6 +17,7 @@
   "hassio_role": "default",
   "homeassistant_api": true,
   "host_network": true,
+  "login_backend": true,
   "auto_uart": true,
   "gpio": true,
   "privileged": [

--- a/node-red/rootfs/etc/cont-init.d/10-requirements.sh
+++ b/node-red/rootfs/etc/cont-init.d/10-requirements.sh
@@ -6,43 +6,10 @@
 # shellcheck disable=SC1091
 source /usr/lib/hassio-addons/base.sh
 
-declare username
-
 # Ensure the credential secret value is set
 if ! hass.config.has_value 'credential_secret'; then
     hass.die 'Setting a credential_secret is REQUIRED!'
 fi
-
-# Require users and password authentication
-if ! hass.config.has_value 'users' \
-    && ! ( \
-        hass.config.exists 'leave_front_door_open' \
-        && hass.config.true 'leave_front_door_open' \
-    );
-then
-    hass.die 'You need to configure at least one user!'
-fi
-
-# Check if configured users meet the requirements
-for user in $(hass.config.get 'users|keys[]'); do
-    username=$(hass.config.get "users[${user}].username")
-
-    # Require http_node username / password
-    if ! hass.config.has_value "users[${user}].username"; then
-        hass.die 'You cannot add users without a username!'
-    fi
-
-    if ! hass.config.has_value "users[${user}].password"; then
-        hass.die "User ${username} does not have a password!";
-    fi
-
-    # Require a secure password
-    if hass.config.has_value "users[${user}].password" \
-        && ! hass.config.is_safe_password "users[${user}].password"; then
-        hass.die \
-          "Please choose a different pass for ${username}, this one is unsafe!"
-    fi
-done
 
 # Require http_node username / password
 if ! hass.config.has_value 'http_node.username' \

--- a/node-red/rootfs/etc/node-red/config.js
+++ b/node-red/rootfs/etc/node-red/config.js
@@ -44,15 +44,16 @@ function getSecret(value) {
 }
 
 // Sane and required defaults for the add-on
-config.uiHost = '0.0.0.0';
 config.debugUseColors = false;
 config.flowFile = 'flows.json';
-config.userDir = '/config/node-red/';
 config.nodesDir = '/config/node-red/nodes';
+config.uiHost = '0.0.0.0';
+config.userDir = '/config/node-red/';
 
 // Several settings
-config.uiPort = options.port;
+config.adminAuth = require('/etc/node-red/ha-auth.js');
 config.credentialSecret = getSecret(options.credential_secret);
+config.uiPort = options.port;
 
 // Set SSL if enabled
 if (options.ssl === true) {
@@ -61,22 +62,6 @@ if (options.ssl === true) {
         cert: fs.readFileSync(`/ssl/${getSecret(options.certfile)}`),
     };
     config.requireHttps = options.require_ssl;
-}
-
-// Create admin users
-if (options.users.length !== 0) {
-    config.adminAuth = {
-        type: "credentials",
-        users: [],
-    };
-
-    options.users.forEach((user, index) => {
-        config.adminAuth.users.push({
-            username: getSecret(user.username),
-            password: bcrypt.hashSync(getSecret(user.password)),
-            permissions: getSecret(user.permissions),
-        });
-    });
 }
 
 // Secure HTTP node

--- a/node-red/rootfs/etc/node-red/ha-auth.js
+++ b/node-red/rootfs/etc/node-red/ha-auth.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var util = require('util');
+var request = require('request');
+var usersMap = new Map();
+
+module.exports = {
+    type: "credentials",
+    users: function(username) {
+        return new Promise(function(resolve) {
+            resolve(usersMap.get(username) || null);
+        });
+    },
+    authenticate: function(username, password) {
+        return new Promise(function(resolve) {
+            request
+                .post(
+                    'http://hassio/auth',
+                    {
+                        headers: {
+                            'X-HASSIO-KEY': process.env.HASSIO_TOKEN
+                        }
+                    }
+                )
+                .auth(username, password, true)
+                .on('error', function(err) {
+                    util.log(`HA Auth - API error ${err}`);
+                    resolve(null);
+                })
+                .on('response', function(res) {
+                    if (res.statusCode != 200) {
+                        util.log(`HA Auth - Failed to authenticate: ${username}`)
+                        resolve(null);
+                    } else {
+                        let user = {
+                            username: username,
+                            permissions: "*"
+                        }
+                        util.log(`HA Auth - ${username} authenticated`);
+                        usersMap.set(username, user);
+                        resolve(user);
+                    }
+                });
+        });
+    },
+    default: function() {
+        return new Promise(function(resolve) {
+            // HA doesn't have a default user
+            resolve(null);
+        });
+    }
+ }


### PR DESCRIPTION
# Proposed Changes

This enables authentication with Home Assistant for Node-RED users.

- Adds HA authentication provider
- Removes all current admin users logic.

## Related Issues

n/a