### PR TITLE
Remove google-home-notify

### DIFF
--- a/node-red/package.json
+++ b/node-red/package.json
@@ -16,6 +16,7 @@
         "node-red-contrib-alexa-home-skill": "0.1.17",
         "node-red-contrib-bigtimer": "2.0.2",
         "node-red-contrib-counter": "0.1.5",
+        "node-red-contrib-google-home-notify": "0.0.6",
         "node-red-contrib-home-assistant-websocket": "0.1.2",
         "node-red-contrib-http-request": "0.1.13",
         "node-red-contrib-influxdb": "0.2.2",
@@ -37,6 +38,9 @@
         "node-red-node-smooth": "0.1.0",
         "node-red-node-suncalc": "0.0.11"
     },
+    "resolutions": {
+        "google-tts-api": "0.0.3",
+    }
     "engines": {
         "node": "4.*.*"
     }

--- a/node-red/package.json
+++ b/node-red/package.json
@@ -16,7 +16,6 @@
         "node-red-contrib-alexa-home-skill": "0.1.17",
         "node-red-contrib-bigtimer": "2.0.2",
         "node-red-contrib-counter": "0.1.5",
-        "node-red-contrib-google-home-notify": "0.0.6",
         "node-red-contrib-home-assistant-websocket": "0.1.2",
         "node-red-contrib-http-request": "0.1.13",
         "node-red-contrib-influxdb": "0.2.2",


### PR DESCRIPTION
# Proposed Changes

> The google-home-notify component is currently broken. There is an issue filed upstream, and even a PR to fix the issue proposed, but the developer seems to be unresponsive. See here: https://github.com/nabbl/node-red-contrib-google-home-notify/issues/25 Propose removing as a pre-installed module until fixed.