### PR TITLE
Update google-tts-api to 0.0.4

### DIFF
--- a/node-red/package.json
+++ b/node-red/package.json
@@ -41,7 +41,7 @@
     },
     "resolutions": {
         "bluebird": "3.5.3",
-        "google-tts-api": "0.0.3"
+        "google-tts-api": "0.0.4"
     },
     "engines": {
         "node": "4.*.*"


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Update google-tts-api to 0.0.4. Fixes the continually-broken google-notify integration. 

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Discussion Around Fix: https://github.com/nabbl/node-red-contrib-google-home-notify/issues/25#issuecomment-443007503