### PR TITLE
Replace node-red-contrib-alexa-home-skill

### DIFF
--- a/node-red/package.json
+++ b/node-red/package.json
@@ -14,7 +14,7 @@
         "js-yaml": "3.12.0",
         "node-red": "0.19.5",
         "node-red-contrib-actionflows": "2.0.1",
-        "node-red-contrib-alexa-home-skill": "0.1.17",
+        "node-red-contrib-alexa-home": "0.3.5",
         "node-red-contrib-bigtimer": "2.0.3",
         "node-red-contrib-counter": "0.1.5",
         "node-red-contrib-google-home-notify": "0.0.6",


### PR DESCRIPTION
Replace node-red-contrib-alexa-home-skill with node-red-contrib-alexa-home.

node-red-contrib-alexa-home-skill relies on a [third-party online service](https://alexa-node-red.bm.hardill.me.uk/) to work, while node-red-contrib-alexa-home works locally.