### PR TITLE
✨ Includes openssh-client for Node-RED Projects

### DIFF
--- a/node-red/Dockerfile
+++ b/node-red/Dockerfile
@@ -26,7 +26,7 @@ RUN \
         git=2.18.1-r0 \
         nodejs=8.14.0-r0 \
         npm=8.14.0-r0 \
-        openssh-keygen=7.7_p1-r3 \
+        openssh-client=7.7_p1-r3 \
         paxctl=0.9-r0 \
         python2=2.7.15-r1 \
     \

--- a/node-red/Dockerfile
+++ b/node-red/Dockerfile
@@ -26,6 +26,7 @@ RUN \
         git=2.18.1-r0 \
         nodejs=8.14.0-r0 \
         npm=8.14.0-r0 \
+        openssh-keygen=7.7_p1-r3 \
         paxctl=0.9-r0 \
         python2=2.7.15-r1 \
     \


### PR DESCRIPTION
# Proposed Changes

To enable Node-RED projects both git and ssh-keygen is needed, the latter is not yet included in the base image: https://nodered.org/docs/user-guide/projects/#enabling-projects

## Related Issues

Closes #95 

<blockquote><div><strong><a href="https://nodered.org/docs/user-guide/projects/#enabling-projects">Node-RED : Projects</a></strong></div></blockquote>