### PR TITLE
⬆️ Upgrades node-red-contrib-bigtimer and node-red-contrib-cast

### DIFF
--- a/node-red/package.json
+++ b/node-red/package.json
@@ -15,7 +15,7 @@
         "node-red": "0.19.5",
         "node-red-contrib-actionflows": "2.0.1",
         "node-red-contrib-alexa-home-skill": "0.1.17",
-        "node-red-contrib-bigtimer": "2.0.7",
+        "node-red-contrib-bigtimer": "2.0.8",
         "node-red-contrib-cast": "0.2.1",
         "node-red-contrib-counter": "0.1.5",
         "node-red-contrib-home-assistant-websocket": "0.5.0",

--- a/node-red/package.json
+++ b/node-red/package.json
@@ -16,7 +16,7 @@
         "node-red-contrib-actionflows": "2.0.1",
         "node-red-contrib-alexa-home-skill": "0.1.17",
         "node-red-contrib-bigtimer": "2.0.8",
-        "node-red-contrib-cast": "0.2.1",
+        "node-red-contrib-cast": "0.2.2",
         "node-red-contrib-counter": "0.1.5",
         "node-red-contrib-home-assistant-websocket": "0.5.0",
         "node-red-contrib-http-request": "0.1.13",


### PR DESCRIPTION
# Proposed Changes
Upgrades node-red-contrib-bigtimer to 2.0.8
Upgrades node-red-contrib-cast to 0.2.2, old release could have some tts problems again.

## Related Issues
Closes #102 