### PR TITLE
⬆️ Upgrades node-red-contrib-home-assistant-websocket to 0.5.1

### DIFF
--- a/node-red/package.json
+++ b/node-red/package.json
@@ -18,7 +18,7 @@
         "node-red-contrib-bigtimer": "2.0.8",
         "node-red-contrib-cast": "0.2.2",
         "node-red-contrib-counter": "0.1.5",
-        "node-red-contrib-home-assistant-websocket": "0.5.0",
+        "node-red-contrib-home-assistant-websocket": "0.5.1",
         "node-red-contrib-http-request": "0.1.13",
         "node-red-contrib-influxdb": "0.2.2",
         "node-red-contrib-interval-length": "0.0.3",


### PR DESCRIPTION
# Proposed Changes

The dependency node-red-contrib-home-assistant-websocket was updated from 0.5.0 to 0.5.1.

Release Notes for 0.5.1

- Fixed get-entities to use the custom label if valid
- Correct possessive apostrophe in trigger state node constraint list (@albertnis)
- Fixed condition where wildcard type state changes fired before current states were actually saved
- Fixed onDeploy for the trigger-state node when using substring/regex for entity id
