### PR TITLE
⬆️ Upgrades node-red-contrib-cast to 0.2.4

### DIFF
--- a/node-red/package.json
+++ b/node-red/package.json
@@ -16,7 +16,7 @@
         "node-red-contrib-actionflows": "2.0.1",
         "node-red-contrib-alexa-home-skill": "0.1.17",
         "node-red-contrib-bigtimer": "2.0.8",
-        "node-red-contrib-cast": "0.2.3",
+        "node-red-contrib-cast": "0.2.4",
         "node-red-contrib-counter": "0.1.5",
         "node-red-contrib-home-assistant-websocket": "0.5.1",
         "node-red-contrib-http-request": "0.1.13",


### PR DESCRIPTION
# Proposed Changes

Upgrade node-red-contrib-cast to 0.2.3

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/