### PR TITLE
Adds node-red-contrib-modbus

### DIFF
--- a/node-red/package.json
+++ b/node-red/package.json
@@ -23,6 +23,7 @@
         "node-red-contrib-influxdb": "0.2.2",
         "node-red-contrib-interval-length": "0.0.3",
         "node-red-contrib-looptimer": "0.0.8",
+        "node-red-contrib-modbus": "4.1.1",
         "node-red-contrib-moment": "3.0.2",
         "node-red-contrib-state-machine": "1.2.0",
         "node-red-contrib-statistics": "2.2.2",


### PR DESCRIPTION
# Proposed Changes

A lot of users seems to have issues with installing `node-red-contrib-modbus`. Adding this node by default, would take away those issues.

## Related Issues

#137 #144 #150 