### PR TITLE
Fix to handle path in certificates

### DIFF
--- a/node-red/rootfs/etc/cont-init.d/nginx.sh
+++ b/node-red/rootfs/etc/cont-init.d/nginx.sh
@@ -18,8 +18,8 @@ if bashio::var.has_value "${admin_port}"; then
         keyfile=$(bashio::config 'keyfile')
 
         mv /etc/nginx/servers/direct-ssl.disabled /etc/nginx/servers/direct.conf
-        sed -i "s/%%certfile%%/${certfile}/g" /etc/nginx/servers/direct.conf
-        sed -i "s/%%keyfile%%/${keyfile}/g" /etc/nginx/servers/direct.conf
+        sed -i "s#%%certfile%%#${certfile}#g" /etc/nginx/servers/direct.conf
+        sed -i "s#%%keyfile%%#${keyfile}#g" /etc/nginx/servers/direct.conf
 
     else
         mv /etc/nginx/servers/direct.disabled /etc/nginx/servers/direct.conf


### PR DESCRIPTION
# Proposed Changes

The regex uses slashes, slashes break paths

## Related Issues

None

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/