### PR TITLE
Update dark theme configuration

### DIFF
--- a/node-red/rootfs/etc/node-red/config.js
+++ b/node-red/rootfs/etc/node-red/config.js
@@ -7,7 +7,6 @@ const bcrypt = require('bcryptjs');
 if (options.dark_mode) {
     config.editorTheme.page = {
         css: '/opt/node_modules/node-red-contrib-theme-midnight-red/midnight.css',
-        scripts: '/opt/node_modules/node-red-contrib-theme-midnight-red/theme-tomorrow.js',
     };
 }
 


### PR DESCRIPTION
# Proposed Changes

Remove the `scripts` line from configuration since it's not needed for the dark theme in Node-RED 1.0 and later.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/