### PR TITLE
:hammer: Reorganize palette categories default order

### DIFF
--- a/node-red/rootfs/etc/node-red/settings.js
+++ b/node-red/rootfs/etc/node-red/settings.js
@@ -165,14 +165,12 @@ module.exports = {
     paletteCategories: [
         'home_assistant',
         'subflows',
-        'input',
-        'output',
+        'common',
         'function',
-        'social',
-        'mobile',
-        'storage',
-        'analysis',
-        'advanced'
+        'network',
+        'sequence',
+        'parser',
+        'storage'
     ],
 
     // Configure the logging output


### PR DESCRIPTION
# Proposed Changes

Reorganize palette categories default order according to what's described in the Node-RED 1.0 release [blog post](https://nodered.org/blog/2019/09/30/version-1-0-released).

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/