### PR TITLE
🔨Install all npm packages in a single command

### DIFF
--- a/node-red/rootfs/etc/cont-init.d/user.sh
+++ b/node-red/rootfs/etc/cont-init.d/user.sh
@@ -4,6 +4,8 @@
 # Executes user customizations on startup
 # ==============================================================================
 
+declare -a npmlist
+
 # Install user configured/requested packages
 if bashio::config.has_value 'system_packages'; then
     apk update \
@@ -21,15 +23,13 @@ if bashio::config.has_value 'npm_packages'; then
 
     bashio::log.info "Starting installation of custom NPM/Node-RED packages..."
     for package in $(bashio::config 'npm_packages'); do
-        npmlist+="$package "
+        npmlist+=("$package")
     done
 
-    bashio::log.debug "Installing packages:$npmlist"
-    # shellcheck disable=SC2086
     npm install \
         --no-optional \
         --only=production \
-        $npmlist \
+        "${npmlist[@]}" \
            || bashio::exit.nok "Failed to install a specified npm package"
 fi
 

--- a/node-red/rootfs/etc/cont-init.d/user.sh
+++ b/node-red/rootfs/etc/cont-init.d/user.sh
@@ -21,12 +21,16 @@ if bashio::config.has_value 'npm_packages'; then
 
     bashio::log.info "Starting installation of custom NPM/Node-RED packages..."
     for package in $(bashio::config 'npm_packages'); do
-        npm install \
-            --no-optional \
-            --only=production \
-            "$package" \
-                || bashio::exit.nok "Failed installing npm package ${package}"
+        npmlist+="$package "
     done
+
+    bashio::log.debug "Installing packages:$npmlist"
+    # shellcheck disable=SC2086
+    npm install \
+        --no-optional \
+        --only=production \
+        $npmlist \
+           || bashio::exit.nok "Failed to install a specified npm package"
 fi
 
 # Executes user commands on startup


### PR DESCRIPTION
# Proposed Changes

Change npm install to be a single command run to reduce audit times.

## Related Issues

Fixes #411 

Outstanding:

~~I needed to stop shellcheck on the command, as quoting it would fail.~~ Changed to array (Sleep helped!)
Is it worth adding this to OS packages as well?