### PR TITLE
Update flows.json to use addon property

### DIFF
--- a/node-red/rootfs/etc/cont-init.d/node-red.sh
+++ b/node-red/rootfs/etc/cont-init.d/node-red.sh
@@ -47,9 +47,6 @@ if ! bashio::fs.directory_exists '/config/node-red/'; then
     # Create random flow id
     id=$(node -e "console.log((1+Math.random()*4294967295).toString(16));")
     sed -i "s/%%ID%%/${id}/" "/config/node-red/flows.json"
-
-    # Set Supervisor token on created flow file
-    sed -i "s/%%TOKEN%%/${SUPERVISOR_TOKEN}/" "/config/node-red/flows.json"
 fi
 
 # Patch Node-RED Dashboard

--- a/node-red/rootfs/etc/node-red/flows.json
+++ b/node-red/rootfs/etc/node-red/flows.json
@@ -1,1 +1,1 @@
-[{"id":"%%ID%%","type":"server","z":"","name":"Home Assistant","url":"http://hassio/homeassistant","pass":"%%TOKEN%%"}]
+[{"id":"%%ID%%","type":"server","z":"","name":"Home Assistant","addon":true}]


### PR DESCRIPTION
# Proposed Changes

Remove unused values, `url` and `pass`, from default flows.json and use a single property to show that the Home Assistant Add-on is being used.

Remove TOKEN string replacement as it is no longer needed.

## Related Issues

https://github.com/zachowj/node-red-contrib-home-assistant-websocket/commit/b0df6d50407d856d49c10e08b5f59f83162abf87

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/