### PR TITLE
Upgrade add-on base image to 9.1.0

### DIFF
--- a/node-red/Dockerfile
+++ b/node-red/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64:9.0.1
+ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64:9.1.0
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 

--- a/node-red/build.json
+++ b/node-red/build.json
@@ -1,9 +1,9 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/hassio-addons/base/aarch64:9.0.1",
-    "amd64": "ghcr.io/hassio-addons/base/amd64:9.0.1",
-    "armhf": "ghcr.io/hassio-addons/base/armhf:9.0.1",
-    "armv7": "ghcr.io/hassio-addons/base/armv7:9.0.1",
-    "i386": "ghcr.io/hassio-addons/base/i386:9.0.1"
+    "aarch64": "ghcr.io/hassio-addons/base/aarch64:9.1.0",
+    "amd64": "ghcr.io/hassio-addons/base/amd64:9.1.0",
+    "armhf": "ghcr.io/hassio-addons/base/armhf:9.1.0",
+    "armv7": "ghcr.io/hassio-addons/base/armv7:9.1.0",
+    "i386": "ghcr.io/hassio-addons/base/i386:9.1.0"
   }
 }


### PR DESCRIPTION
# Proposed Changes

Upgrades the add-on base image to 9.1.0.
This gives access to tempio, to resolve the Lua lightpoint issue we are experiencing (in a follow-up PR).