### PR TITLE
Remove obsolete webui from configuration

### DIFF
--- a/node-red/config.json
+++ b/node-red/config.json
@@ -4,7 +4,6 @@
   "slug": "nodered",
   "description": "Flow-based programming for the Internet of Things",
   "url": "https://github.com/hassio-addons/addon-node-red",
-  "webui": "[PROTO:ssl]://[HOST]:[PORT:80]",
   "ingress": true,
   "ingress_port": 0,
   "panel_icon": "mdi:sitemap",


### PR DESCRIPTION
# Proposed Changes

Remove the `webui` configuration parameter from the add-on configuration. Since this add-on uses Ingress, it became kinda useless.
