### PR TITLE
Remove NGINX access log from Supervisor log output

### DIFF
--- a/node-red/rootfs/etc/nginx/nginx.conf
+++ b/node-red/rootfs/etc/nginx/nginx.conf
@@ -27,11 +27,7 @@ events {
 http {
     include /etc/nginx/includes/mime.types;
 
-    log_format homeassistant '[$time_local] $status '
-                                  '$http_x_forwarded_for($remote_addr) '
-                                  '$request ($http_user_agent)';
-
-    access_log              /proc/1/fd/1 homeassistant;
+    access_log              off;
     client_max_body_size    4G;
     default_type            application/octet-stream;
     gzip                    on;


### PR DESCRIPTION
# Proposed Changes

Removes NGINX access log output from the Supervisor logs.

closes #863
