### PR TITLE
Replace state-machine with persistent-fsm

### DIFF
--- a/node-red/package.json
+++ b/node-red/package.json
@@ -25,7 +25,7 @@
     "node-red-contrib-looptimer": "0.0.8",
     "node-red-contrib-modbus": "5.13.3",
     "node-red-contrib-moment": "4.0.0",
-    "node-red-contrib-state-machine": "1.2.0",
+    "node-red-contrib-persistent-fsm": "1.1.0",
     "node-red-contrib-statistics": "2.2.2",
     "node-red-contrib-stoptimer": "0.0.7",
     "node-red-contrib-sunevents": "2.0.3",


### PR DESCRIPTION
# Proposed Changes

Replaces the state-machine node with the persistent-fsm node. It's a fork, but resolved the deprecation warnings. Drop-in replacement.

## Related Issues

fixes #872
