### PR TITLE
Grant read access to backups

### DIFF
--- a/node-red/config.json
+++ b/node-red/config.json
@@ -26,7 +26,7 @@
   "privileged": ["SYS_RAWIO"],
   "devices": ["/dev/mem"],
   "apparmor": false,
-  "map": ["config:rw", "media:rw", "share:rw", "ssl"],
+  "map": ["config:rw", "media:rw", "share:rw", "ssl", "backup"],
   "options": {
     "credential_secret": "",
     "dark_mode": false,


### PR DESCRIPTION
# Proposed Changes

Grant node red access to the HomeAssistant backup directory
https://developers.home-assistant.io/docs/add-ons/configuration/#add-on-config

This would allow some cool backup flows like automatically uploading new backups to an offsite storage

