### PR TITLE
Add support for the theme collection

### DIFF
--- a/node-red/DOCS.md
+++ b/node-red/DOCS.md
@@ -110,13 +110,28 @@ You might need it in the future! (e.g., When restoring a backup).
 Node-RED from being able to decrypt your existing credentials and they will be
 lost._
 
-### Option: `dark_mode`
+### Option: `dark_mode` (DEPRECATED)
+
+**Note**: _This option is **DEPRECATED** and will be removed in a future version
+of the add-on._
 
 When set to `true`, the Midnight Node-RED theme by [Mauricio Bonani][bonanitech]
 will be enabled. For more information and a glance at how it looks,
 see the GitHub repository of this theme:
 
 <https://github.com/node-red-contrib-themes/midnight-red>
+
+### Option: `theme`
+
+Sets one of the Node-RED themes. Currently available options:
+
+- `dark`
+- `midnight-red`
+- `oled`
+- `solarized-dark`
+- `solarized-light`
+
+**Note**: _The option `dark_mode` must be set to false for this option to work._
 
 ### Option: `http_node`
 

--- a/node-red/DOCS.md
+++ b/node-red/DOCS.md
@@ -114,6 +114,7 @@ lost._
 
 Sets one of the Node-RED themes. Currently available options:
 
+- `default`
 - `dark`
 - `midnight-red`
 - `oled`

--- a/node-red/DOCS.md
+++ b/node-red/DOCS.md
@@ -110,17 +110,6 @@ You might need it in the future! (e.g., When restoring a backup).
 Node-RED from being able to decrypt your existing credentials and they will be
 lost._
 
-### Option: `dark_mode` (DEPRECATED)
-
-**Note**: _This option is **DEPRECATED** and will be removed in a future version
-of the add-on._
-
-When set to `true`, the Midnight Node-RED theme by [Mauricio Bonani][bonanitech]
-will be enabled. For more information and a glance at how it looks,
-see the GitHub repository of this theme:
-
-<https://github.com/node-red-contrib-themes/midnight-red>
-
 ### Option: `theme`
 
 Sets one of the Node-RED themes. Currently available options:
@@ -130,8 +119,6 @@ Sets one of the Node-RED themes. Currently available options:
 - `oled`
 - `solarized-dark`
 - `solarized-light`
-
-**Note**: _The option `dark_mode` must be set to false for this option to work._
 
 ### Option: `http_node`
 
@@ -297,7 +284,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 [alpine-packages]: https://pkgs.alpinelinux.org/packages
-[bonanitech]: https://github.com/bonanitech
 [contributors]: https://github.com/hassio-addons/addon-node-red/graphs/contributors
 [discord-ha]: https://discord.gg/c5DvZ4e
 [discord]: https://discord.me/hassioaddons

--- a/node-red/config.json
+++ b/node-red/config.json
@@ -29,7 +29,6 @@
   "map": ["config:rw", "media:rw", "share:rw", "ssl"],
   "options": {
     "credential_secret": "",
-    "dark_mode": false,
     "theme": "",
     "http_node": {
       "username": "",
@@ -50,8 +49,8 @@
   "schema": {
     "log_level": "list(trace|debug|info|notice|warning|error|fatal)?",
     "credential_secret": "password",
-    "dark_mode": "bool",
     "theme": "match((dark|midnight-red|oled|solarized-dark|solarized-light)(-scroll)?)?",
+    "dark_mode": "bool?",
     "http_node": {
       "username": "str",
       "password": "password"

--- a/node-red/config.json
+++ b/node-red/config.json
@@ -50,7 +50,7 @@
     "log_level": "list(trace|debug|info|notice|warning|error|fatal)?",
     "credential_secret": "password",
     "dark_mode": "bool?",
-    "theme": "match((dark|midnight-red|oled|solarized-dark|solarized-light)(-scroll)?|(default))",
+    "theme": "list(default|dark|midnight-red|oled|solarized-dark|solarized-light)",
     "http_node": {
       "username": "str",
       "password": "password"

--- a/node-red/config.json
+++ b/node-red/config.json
@@ -50,7 +50,7 @@
     "log_level": "list(trace|debug|info|notice|warning|error|fatal)?",
     "credential_secret": "password",
     "dark_mode": "bool?",
-    "theme": "list(default|dark|midnight-red|oled|solarized-dark|solarized-light)",
+    "theme": "list(default|dark|midnight-red|oled|solarized-dark|solarized-light)?",
     "http_node": {
       "username": "str",
       "password": "password"

--- a/node-red/config.json
+++ b/node-red/config.json
@@ -29,7 +29,7 @@
   "map": ["config:rw", "media:rw", "share:rw", "ssl"],
   "options": {
     "credential_secret": "",
-    "theme": "",
+    "theme": "default",
     "http_node": {
       "username": "",
       "password": ""
@@ -49,8 +49,8 @@
   "schema": {
     "log_level": "list(trace|debug|info|notice|warning|error|fatal)?",
     "credential_secret": "password",
-    "theme": "match((dark|midnight-red|oled|solarized-dark|solarized-light)(-scroll)?)?",
     "dark_mode": "bool?",
+    "theme": "match((dark|midnight-red|oled|solarized-dark|solarized-light)(-scroll)?|(default))",
     "http_node": {
       "username": "str",
       "password": "password"

--- a/node-red/config.json
+++ b/node-red/config.json
@@ -30,6 +30,7 @@
   "options": {
     "credential_secret": "",
     "dark_mode": false,
+    "theme": "",
     "http_node": {
       "username": "",
       "password": ""
@@ -50,6 +51,7 @@
     "log_level": "list(trace|debug|info|notice|warning|error|fatal)?",
     "credential_secret": "password",
     "dark_mode": "bool",
+    "theme": "match((dark|midnight-red|oled|solarized-dark|solarized-light)(-scroll)?)?",
     "http_node": {
       "username": "str",
       "password": "password"

--- a/node-red/package.json
+++ b/node-red/package.json
@@ -46,7 +46,7 @@
     "node-red-node-smooth": "0.1.2",
     "node-red-node-suncalc": "1.0.1",
     "node-red-node-twitter": "1.2.0",
-    "@node-red-contrib-themes/midnight-red": "1.5.0"
+    "@node-red-contrib-themes/theme-collection": "1.0.0"
   },
   "engines": {
     "node": ">=10"

--- a/node-red/rootfs/etc/cont-init.d/node-red.sh
+++ b/node-red/rootfs/etc/cont-init.d/node-red.sh
@@ -72,6 +72,15 @@ else
     sed -i "s/%%SSL%%/false/" "/opt/node_modules/node-red-dashboard/nodes/ui_base.html"
 fi
 
+# Warns about dark_mode deprecation
+if bashio::config.has_value 'dark_mode'; then
+    bashio::log.warning
+    bashio::log.warning "The dark_mode option has been deprecated and will be"
+    bashio::log.warning "removed in a future version. Please use the theme"
+    bashio::log.warning "option instead."
+    bashio::log.warning
+fi
+
 # Ensures conflicting Node-RED packages are absent
 cd /config/node-red || bashio::exit.nok "Could not change directory to Node-RED"
 if bashio::fs.file_exists "/config/node-red/package.json"; then

--- a/node-red/rootfs/etc/node-red/config.js
+++ b/node-red/rootfs/etc/node-red/config.js
@@ -10,7 +10,7 @@ if (options.dark_mode) {
   };
 }
 // Set theme
-else if (options.theme) {
+else if ("theme" in options) {
   if (options.theme !== "default") {
     config.editorTheme = {
       theme: options.theme,

--- a/node-red/rootfs/etc/node-red/config.js
+++ b/node-red/rootfs/etc/node-red/config.js
@@ -11,9 +11,11 @@ if (options.dark_mode) {
 }
 // Set theme
 else if (options.theme) {
-  config.editorTheme = {
-    theme: options.theme,
-  };
+  if (options.theme !== "default") {
+    config.editorTheme = {
+      theme: options.theme,
+    };
+  }
 }
 
 // Sane and required defaults for the add-on

--- a/node-red/rootfs/etc/node-red/config.js
+++ b/node-red/rootfs/etc/node-red/config.js
@@ -9,6 +9,12 @@ if (options.dark_mode) {
     css: "/opt/node_modules/@node-red-contrib-themes/midnight-red/theme.css",
   };
 }
+// Set theme
+else if (options.theme) {
+  config.editorTheme = {
+    theme: options.theme,
+  };
+}
 
 // Sane and required defaults for the add-on
 config.debugUseColors = false;

--- a/node-red/rootfs/etc/node-red/config.js
+++ b/node-red/rootfs/etc/node-red/config.js
@@ -5,8 +5,8 @@ const bcrypt = require("bcryptjs");
 
 // Set dark theme if enabled
 if (options.dark_mode) {
-  config.editorTheme.page = {
-    css: "/opt/node_modules/@node-red-contrib-themes/midnight-red/theme.css",
+  config.editorTheme = {
+    theme: "midnight-red",
   };
 }
 // Set theme


### PR DESCRIPTION
# Proposed Changes

This adds the collection of themes created by the @node-red-contrib-themes team, giving the users the option to choose which theme to use in their systems.

## Related Issues

N/A

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
