### PR TITLE
Add note to docs about credential secrets and projects

### DIFF
--- a/node-red/DOCS.md
+++ b/node-red/DOCS.md
@@ -110,6 +110,9 @@ You might need it in the future! (e.g., When restoring a backup).
 Node-RED from being able to decrypt your existing credentials and they will be
 lost._
 
+**Note**: _If you have manually enabled the use of project in Node-RED, this
+option will, eventhough required, be ignored by Node-RED._
+
 ### Option: `theme`
 
 Sets one of the Node-RED themes. Currently available options:


### PR DESCRIPTION
# Proposed Changes

Adds a small note to the credential_secret option in the add-on documentation, to make clear it is not used when one has enabled the use of Node-RED projects.

## Related Issues

fixes #994
