### PR TITLE
Home matic ccu rpc ports

### DIFF
--- a/node-red/config.json
+++ b/node-red/config.json
@@ -11,10 +11,15 @@
   "homeassistant": "0.92.0b2",
   "arch": ["aarch64", "amd64", "armhf", "armv7", "i386"],
   "ports": {
-    "80/tcp": 1880
+    "80/tcp": 1880,
+    "2048/tcp": 2048,
+    "2049/tcp": 2049
+
   },
   "ports_description": {
-    "80/tcp": "Web interface"
+    "80/tcp": "Web interface",
+    "2048/tcp": "HomeMatic CCU BINRPC listening Port",
+    "2049/tcp": "HomeMatic CCU XMLRPC listening Port"
   },
   "hassio_api": true,
   "hassio_role": "manager",

--- a/node-red/config.json
+++ b/node-red/config.json
@@ -12,8 +12,8 @@
   "arch": ["aarch64", "amd64", "armhf", "armv7", "i386"],
   "ports": {
     "80/tcp": 1880,
-    "2048/tcp": 2048,
-    "2049/tcp": 2049
+    "2048/tcp": null,
+    "2049/tcp": null
 
   },
   "ports_description": {

--- a/node-red/config.json
+++ b/node-red/config.json
@@ -13,13 +13,29 @@
   "ports": {
     "80/tcp": 1880,
     "2048/tcp": null,
-    "2049/tcp": null
+    "2049/tcp": null,
+    "2050/tcp": null,
+    "2051/tcp": null,
+    "2052/tcp": null,
+    "2053/tcp": null,
+    "2054/tcp": null,
+    "2055/tcp": null,
+    "2056/tcp": null,
+    "2057/tcp": null
 
   },
   "ports_description": {
     "80/tcp": "Web interface",
-    "2048/tcp": "HomeMatic CCU BINRPC listening Port",
-    "2049/tcp": "HomeMatic CCU XMLRPC listening Port"
+    "2048/tcp": "reserved port 1 - e.g. HomeMatic CCU BINRPC listening Port",
+    "2049/tcp": "reserved port 2 - e.g. HomeMatic CCU XMLRPC listening Port",
+    "2050/tcp": "reserved port 3",
+    "2051/tcp": "reserved port 4",
+    "2052/tcp": "reserved port 5",
+    "2053/tcp": "reserved port 6",
+    "2054/tcp": "reserved port 7",
+    "2055/tcp": "reserved port 8",
+    "2056/tcp": "reserved port 9",
+    "2057/tcp": "reserved port 10"
   },
   "hassio_api": true,
   "hassio_role": "manager",


### PR DESCRIPTION
# Proposed Changes

Added some additional ports to configuration. This is needed by the node-red-contrib-ccu pallette for example.

## Related Issues

Currently, there was no actual Issue related to this.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
