### PR TITLE
Add contextStorage option to settings.js

### DIFF
--- a/node-red/rootfs/etc/node-red/settings.js
+++ b/node-red/rootfs/etc/node-red/settings.js
@@ -158,12 +158,9 @@ module.exports = {
   },
   
   contextStorage: {
-    default: {
-      module: "localfilesystem"
-    },
-    memoryOnly: {
-      module: "memory"
-    }
+   default: "memory",
+   memory: { module: 'memory' },
+   file: { module: 'localfilesystem' }
   },
   
   // The following property can be used to order the categories in the editor

--- a/node-red/rootfs/etc/node-red/settings.js
+++ b/node-red/rootfs/etc/node-red/settings.js
@@ -156,7 +156,16 @@ module.exports = {
     // jfive:require("johnny-five"),
     // j5board:require("johnny-five").Board({repl:false})
   },
-
+  
+  contextStorage: {
+    default: {
+          module: "localfilesystem"
+      },
+      memoryOnly: {
+          module: "memory"
+      }
+  },
+  
   // The following property can be used to order the categories in the editor
   // palette. If a node's category is not in the list, the category will get
   // added to the end of the palette.

--- a/node-red/rootfs/etc/node-red/settings.js
+++ b/node-red/rootfs/etc/node-red/settings.js
@@ -159,11 +159,11 @@ module.exports = {
   
   contextStorage: {
     default: {
-          module: "localfilesystem"
-      },
-      memoryOnly: {
-          module: "memory"
-      }
+      module: "localfilesystem"
+    },
+    memoryOnly: {
+      module: "memory"
+    }
   },
   
   // The following property can be used to order the categories in the editor


### PR DESCRIPTION
# Proposed Changes

Allows Node-RED to store context variables by default on the file system instead of on system memory. Allows flow and global variables to persist when restarting Node-RED. Users are still able to decide when setting these variables if they want it stored locally or in memory, but previously memory was the only option. An alternative would be setting memory as the default but allowing local file system storage, which retains current functionality but lets users have the option.

## Related Issues

N/A

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
