### PR TITLE
🔥 Remove dark mode support, has been replaced by themes

### DIFF
--- a/node-red/config.json
+++ b/node-red/config.json
@@ -49,7 +49,6 @@
   "schema": {
     "log_level": "list(trace|debug|info|notice|warning|error|fatal)?",
     "credential_secret": "password",
-    "dark_mode": "bool?",
     "theme": "list(default|dark|midnight-red|oled|solarized-dark|solarized-light)?",
     "http_node": {
       "username": "str",

--- a/node-red/rootfs/etc/cont-init.d/node-red.sh
+++ b/node-red/rootfs/etc/cont-init.d/node-red.sh
@@ -72,15 +72,6 @@ else
     sed -i "s/%%SSL%%/false/" "/opt/node_modules/node-red-dashboard/nodes/ui_base.html"
 fi
 
-# Warns about dark_mode deprecation
-if bashio::config.has_value 'dark_mode'; then
-    bashio::log.warning
-    bashio::log.warning "The dark_mode option has been deprecated and will be"
-    bashio::log.warning "removed in a future version. Please use the theme"
-    bashio::log.warning "option instead."
-    bashio::log.warning
-fi
-
 # Ensures conflicting Node-RED packages are absent
 cd /config/node-red || bashio::exit.nok "Could not change directory to Node-RED"
 if bashio::fs.file_exists "/config/node-red/package.json"; then

--- a/node-red/rootfs/etc/node-red/config.js
+++ b/node-red/rootfs/etc/node-red/config.js
@@ -3,12 +3,7 @@ const fs = require("fs");
 const options = JSON.parse(fs.readFileSync("/data/options.json", "utf8"));
 const bcrypt = require("bcryptjs");
 
-// Set dark theme if enabled
-if (options.dark_mode) {
-  config.editorTheme.theme = "midnight-red";
-}
-// Set theme
-else if ("theme" in options) {
+if ("theme" in options) {
   if (options.theme !== "default") {
     config.editorTheme.theme = options.theme;
   }


### PR DESCRIPTION
# Proposed Changes

Removes the `dark_mode` configuration setting.

This setting has been deprecated for quite some time now and replaces by the `theme` configuration option.

