### PR TITLE
🔑 Use bearer authorization headers for HA auth

### DIFF
--- a/node-red/rootfs/etc/nginx/templates/direct.gtpl
+++ b/node-red/rootfs/etc/nginx/templates/direct.gtpl
@@ -21,7 +21,7 @@ server {
         proxy_pass              http://supervisor/auth;
         proxy_pass_request_body off;
         proxy_set_header        Content-Length "";
-        proxy_set_header        X-Supervisor-Token "{{ env "SUPERVISOR_TOKEN" }}";
+        proxy_set_header        Authorization "Bearer {{ env "SUPERVISOR_TOKEN" }}";
     }
     {{ end }}
 


### PR DESCRIPTION
# Proposed Changes

Use bearer authorization headers for HA auth instead of the previous X-Supervisor-Token header.
