### PR TITLE
🔥 Clean up HIBP logic, as it is now handled by the Supervisor

### DIFF
--- a/node-red/config.json
+++ b/node-red/config.json
@@ -66,7 +66,6 @@
     "system_packages": ["str"],
     "npm_packages": ["str"],
     "init_commands": ["str"],
-    "i_like_to_be_pwned": "bool?",
     "leave_front_door_open": "bool?"
   }
 }

--- a/node-red/rootfs/etc/cont-init.d/node-red.sh
+++ b/node-red/rootfs/etc/cont-init.d/node-red.sh
@@ -23,18 +23,6 @@ if bashio::config.is_empty 'credential_secret'; then
     bashio::exit.nok
 fi
 
- # Require a secure http_node password
-if bashio::config.has_value 'http_node.password' \
-    && ! bashio::config.true 'i_like_to_be_pwned'; then
-    bashio::config.require.safe_password 'http_node.password'
-fi
-
- # Require a secure http_static password
-if bashio::config.has_value 'http_static.password' \
-    && ! bashio::config.true 'i_like_to_be_pwned'; then
-    bashio::config.require.safe_password 'http_static.password'
-fi
-
 # Ensure configuration exists
 if ! bashio::fs.directory_exists '/config/node-red/'; then
     mkdir -p /config/node-red/nodes \


### PR DESCRIPTION
# Proposed Changes

This PR removes the HIBP logic and the `i_like_to_be_pwnd` configuration option.
HIBP checks are now done by the Home Assistant Supervisor and is no longer a task that the add-on needs to do.
