### PR TITLE
🔥 Clean up unused require_ssl setting

### DIFF
--- a/node-red/DOCS.md
+++ b/node-red/DOCS.md
@@ -44,7 +44,6 @@ http_static:
 ssl: true
 certfile: fullchain.pem
 keyfile: privkey.pem
-require_ssl: true
 system_packages:
   - ffmpeg
 npm_packages:
@@ -93,11 +92,6 @@ The certificate file to use for SSL.
 The private key file to use for SSL.
 
 **Note**: _The file MUST be stored in `/ssl/`, which is the default_
-
-### Option: `require_ssl`
-
-This option can be used to cause insecure HTTP connections to be redirected
-to HTTPS. This is recommended when you have SSL enabled.
 
 ### Option: `credential_secret`
 

--- a/node-red/config.json
+++ b/node-red/config.json
@@ -42,7 +42,6 @@
     "ssl": true,
     "certfile": "fullchain.pem",
     "keyfile": "privkey.pem",
-    "require_ssl": true,
     "system_packages": [],
     "npm_packages": [],
     "init_commands": []
@@ -62,7 +61,6 @@
     "ssl": "bool",
     "certfile": "str",
     "keyfile": "str",
-    "require_ssl": "bool",
     "system_packages": ["str"],
     "npm_packages": ["str"],
     "init_commands": ["str"],

--- a/node-red/rootfs/etc/node-red/settings.js
+++ b/node-red/rootfs/etc/node-red/settings.js
@@ -35,7 +35,6 @@
  * - logging.console.level (log_level in the add-on configuration)
  * - httpNodeAuth (http_node settings in the add-on configuration)
  * - httpStaticAuth (http_static settings in the add-on configuration)
- * - requireHttps (require_ssl setting in the add-on configuration)
  * - httpNodeRoot (set fixed to `/endpoint` )
  *
  * If you like to change those settings, some are available via the add-on


### PR DESCRIPTION
# Proposed Changes

This PR cleans up an unused setting: `require_ssl` and is thus removed from the configuration.
This setting can be removed from your configuration without impact on anything else, as it wasn't used.

closes #1061