### PR TITLE
Don't enable ssl by default #1112

### DIFF
--- a/node-red/config.json
+++ b/node-red/config.json
@@ -39,7 +39,7 @@
       "username": "",
       "password": ""
     },
-    "ssl": true,
+    "ssl": false,
     "certfile": "fullchain.pem",
     "keyfile": "privkey.pem",
     "system_packages": [],


### PR DESCRIPTION
# Proposed Changes

The docs don't indicate SSL is required, and new users have to figure that out by looking at the addon logs. While SSL is great to encourage, I don't think it can be required given how difficult it is to set up (and given that Home Assistant itself doesn't require SSL).

## Related Issues

> #1112 
