### PR TITLE
Add links to nodered.org in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Flow-based programming for the Internet of Things.
 
 ## About
 
-Node-RED is a programming tool for wiring together hardware devices,
+[Node-RED][nodered] is a programming tool for wiring together hardware devices,
 APIs and online services in new and interesting ways.
 
 It provides a browser-based editor that makes it easy to wire together flows
@@ -48,6 +48,7 @@ You have several options to get them answered:
   Assistant discussions and questions.
 - The Home Assistant [Community Forum][forum].
 - Join the [Reddit subreddit][reddit] in [/r/homeassistant][reddit]
+- The [Node-RED documentation][nodered-docs]
 
 You could also [open an issue here][issue] GitHub.
 
@@ -122,6 +123,8 @@ SOFTWARE.
 [issue]: https://github.com/hassio-addons/addon-node-red/issues
 [license-shield]: https://img.shields.io/github/license/hassio-addons/addon-node-red.svg
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2021.svg
+[nodered]: https://nodered.org
+[nodered-docs]: https://nodered.org/docs
 [patreon-shield]: https://frenck.dev/wp-content/uploads/2019/12/patreon.png
 [patreon]: https://www.patreon.com/frenck
 [project-stage-shield]: https://img.shields.io/badge/project%20stage-production%20ready-brightgreen.svg

--- a/node-red/DOCS.md
+++ b/node-red/DOCS.md
@@ -1,6 +1,6 @@
 # Home Assistant Community Add-on: Node-RED
 
-Node-RED is a programming tool for wiring together hardware devices,
+[Node-RED][nodered] is a programming tool for wiring together hardware devices,
 APIs and online services in new and interesting ways.
 
 It provides a browser-based editor that makes it easy to wire together flows
@@ -240,6 +240,7 @@ You have several options to get them answered:
   Assistant discussions and questions.
 - The Home Assistant [Community Forum][forum].
 - Join the [Reddit subreddit][reddit] in [/r/homeassistant][reddit]
+- The [Node-RED documentation][nodered-docs]
 
 You could also [open an issue here][issue] GitHub.
 
@@ -282,6 +283,8 @@ SOFTWARE.
 [frenck]: https://github.com/frenck
 [issue]: https://github.com/hassio-addons/addon-node-red/issues
 [node-red-nodes]: https://flows.nodered.org/?type=node&num_pages=1
+[nodered]: https://nodered.org
+[nodered-docs]: https://nodered.org/docs
 [npm-packages]: https://www.npmjs.com
 [reddit]: https://reddit.com/r/homeassistant
 [releases]: https://github.com/hassio-addons/addon-node-red/releases


### PR DESCRIPTION
# Proposed Changes

Add links to nodered.org in the documentation.

When I first started to use Home Assistant, I had never heard about Node-RED. I saw it in the list of available addons, took a quick look at the documentation and figured that it was some Home Assistant-specific thing since there were no references to an upstream project. Had so much else to figure out at that point so I left it at that. Didn't really understand what it was for until much later when I saw someone using it in a Youtube review for some Zigbee lamp.

After finding the Node-RED homepage with its introduction information and tutorials I only wish I had found it earlier, before burning myself out on the frustratingly unintuitive and underdocumented world of core HA automation.