### PR TITLE
Set minimum node version to 12

### DIFF
--- a/node-red/package.json
+++ b/node-red/package.json
@@ -49,6 +49,6 @@
     "@node-red-contrib-themes/theme-collection": "2.1.3"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   }
 }


### PR DESCRIPTION
# Proposed Changes

Node v10 reached the end-of-life last April. In this case, it's better to use v12, which is still in development.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
