### PR TITLE
Map backup folder

### DIFF
--- a/node-red/config.yaml
+++ b/node-red/config.yaml
@@ -36,6 +36,7 @@ map:
   - config:rw
   - media:rw
   - share:rw
+  - backup
   - ssl
 options:
   credential_secret: ""


### PR DESCRIPTION
# Problem/Motivation

> To automate remote backup by using rclone installed as system package in nodedred addon config.

## Expected behavior

> Map /mnt/data/supervisor/backup to /backup as read-only

## Actual behavior

> not mapped

## Steps to reproduce

> /backup is not currently mapped, so can be reproduce by using any version.

## Proposed changes

> (If you have a proposed change, workaround or fix,
> describe the rationale behind it)
