### PR TITLE
🔨 Reorganize palette categories  order

### DIFF
--- a/node-red/rootfs/etc/node-red/settings.js
+++ b/node-red/rootfs/etc/node-red/settings.js
@@ -162,6 +162,7 @@ module.exports = {
   // If not set, the following default order is used:
   paletteCategories: [
     "home_assistant",
+    "home_assistant entities",
     "subflows",
     "common",
     "function",


### PR DESCRIPTION
# Proposed Changes

Place the "home_assistant entities" category right below the "home_assistant" category in the palette.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
