### PR TITLE
🔨 Remove node-red-contrib-actionflows

### DIFF
--- a/node-red/package.json
+++ b/node-red/package.json
@@ -14,7 +14,6 @@
     "js-yaml": "4.1.0",
     "full-icu": "1.4.0",
     "node-red": "2.2.0",
-    "node-red-contrib-actionflows": "2.0.4",
     "node-red-contrib-alexa-home-skill": "0.1.19",
     "node-red-contrib-bigtimer": "2.8.1",
     "node-red-contrib-cast": "0.2.17",


### PR DESCRIPTION
# Proposed Changes

Remove node-red-contrib-actionflows due to non-maintained and errors

Thought I may aswell PR it, marking as breaking-change as users of the module will be impacted.

Need to follow up to see how many other bundled packages are unmaintained.

## Related Issues

Should fix #1258 fix #1256
