### PR TITLE
Change minimum Home Assistant version to 2021.3.0

### DIFF
--- a/node-red/config.yaml
+++ b/node-red/config.yaml
@@ -9,7 +9,7 @@ ingress_port: 0
 ingress_stream: true
 panel_icon: mdi:sitemap
 init: false
-homeassistant: 0.92.0b2
+homeassistant: 2021.3.0
 arch:
   - aarch64
   - amd64


### PR DESCRIPTION
# Proposed Changes

Starting with version 0.42.0 of node-red-contrib-home-assistant-websocket the minimum Home Assistant version is 2021.3.0. This requirement is due to the use of targets in service calls.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
