### PR TITLE
:ambulance: Ensure add-on starts without internet

### DIFF
--- a/node-red/rootfs/etc/cont-init.d/node-red.sh
+++ b/node-red/rootfs/etc/cont-init.d/node-red.sh
@@ -67,5 +67,5 @@ if bashio::fs.file_exists "/config/node-red/package.json"; then
         node-red-contrib-home-assistant \
         node-red-contrib-home-assistant-llat \
         node-red-contrib-home-assistant-ws \
-            || bashio::exit.nok "Failed un-installing conflicting packages"
+            || bashio::log.warning "Failed un-installing conflicting packages"
 fi


### PR DESCRIPTION
# Proposed Changes

When (for whatever reason), NPM fails to connect to the package index, it will error out and the add-on will fail to start.

This also means that starting without internet or when NPM has an outage is kinda hard...
This PR ensures the add-on still continues starting and does not break on the handling of the conflicting packages.

fixes #1365
