### PR TITLE
Add new themes introduced in @node-red-contrib-themes/theme-collection v3.0

### DIFF
--- a/node-red/DOCS.md
+++ b/node-red/DOCS.md
@@ -114,12 +114,20 @@ option will, eventhough required, be ignored by Node-RED._
 Sets one of the Node-RED themes. Currently available options:
 
 - `default`
+- `aurora`
+- `cobalt2`
 - `dark`
 - `dracula`
+- `espresso-libre`
 - `midnight-red`
+- `monoindustrial`
+- `monokai`
+- `oceanic-next`
 - `oled`
 - `solarized-dark`
 - `solarized-light`
+- `tokyo-night`
+- `zenburn`
 
 ### Option: `http_node`
 

--- a/node-red/config.yaml
+++ b/node-red/config.yaml
@@ -50,7 +50,7 @@ options:
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   credential_secret: password
-  theme: list(default|dark|dracula|midnight-red|oled|solarized-dark|solarized-light)?
+  theme: list(default|aurora|cobalt2|dark|dracula|espresso-libre|midnight-red|monoindustrial|monokai|oceanic-next|oled|solarized-dark|solarized-light|tokyo-night|zenburn)?
   http_node:
     username: str
     password: password


### PR DESCRIPTION
# Proposed Changes

Node-RED Contrib Theme Collection version 3.0 introduced new themes:

- aurora
- cobalt2
- espresso-libre
- monoindustrial
- monokai
- oceanic-next
- tokyo-night
- zenburn

This PR adds them to the add-on config.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
