### PR TITLE
:books: Fix My Home Assistant link

### DIFF
--- a/node-red/DOCS.md
+++ b/node-red/DOCS.md
@@ -299,7 +299,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 [addon-badge]: https://my.home-assistant.io/badges/supervisor_addon.svg
-[addon]: https://my.home-assistant.io/redirect/supervisor_addon/?addon=a0d7b954_example&repository_url=https%3A%2F%2Fgithub.com%2Fhassio-addons%2Frepository
+[addon]: https://my.home-assistant.io/redirect/supervisor_addon/?addon=a0d7b954_nodered&repository_url=https%3A%2F%2Fgithub.com%2Fhassio-addons%2Frepository
 [alpine-packages]: https://pkgs.alpinelinux.org/packages
 [contributors]: https://github.com/hassio-addons/addon-node-red/graphs/contributors
 [discord-ha]: https://discord.gg/c5DvZ4e


### PR DESCRIPTION
# Proposed Changes

Fixes the My Home Assistant Link/Badge to install the add-on.

## Related Issues

fixes #1427
