### PR TITLE
⏱ Add startup timeout for health check

### DIFF
--- a/node-red/Dockerfile
+++ b/node-red/Dockerfile
@@ -58,7 +58,8 @@ RUN \
 COPY rootfs /
 
 # Health check
-HEALTHCHECK CMD curl --fail http://127.0.0.1:46836 || exit 1
+HEALTHCHECK --start-period=10m \
+    CMD curl --fail http://127.0.0.1:46836 || exit 1
 
 # Build arguments
 ARG BUILD_ARCH


### PR DESCRIPTION
# Proposed Changes

Adds a startup delay for health checks, giving dependencies time to install.


fixes #1474
