### PR TITLE
⬆️ Upgrades add-on base image to 13.0.0

### DIFF
--- a/node-red/Dockerfile
+++ b/node-red/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base:12.2.7
+ARG BUILD_FROM=ghcr.io/hassio-addons/base:13.0.0
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -14,31 +14,29 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Setup base
 RUN \
     apk add --no-cache --virtual .build-dependencies \
-        g++=11.2.1_git20220219-r2 \
-        gcc=11.2.1_git20220219-r2 \
+        g++=12.2.1_git20220924-r4 \
+        gcc=12.2.1_git20220924-r4 \
         libc-dev=0.7.2-r3 \
-        linux-headers=5.16.7-r1 \
-        make=4.3-r0 \
-        py3-pip=22.1.1-r0 \
-        python3-dev=3.10.8-r0 \
-        python3=3.10.8-r0 \
+        linux-headers=5.19.5-r0 \
+        make=4.3-r1 \
+        py3-pip=22.3.1-r1 \
+        python3-dev=3.10.9-r0 \
+        python3=3.10.9-r0 \
     \
     && apk add --no-cache \
-        git=2.36.3-r0 \
-        icu-data-full=71.1-r2 \
+        git=2.38.2-r0 \
+        icu-data-full=72.1-r1 \
         nginx=1.22.1-r0 \
-        nodejs=16.17.1-r0 \
-        npm=8.10.0-r0 \
-        openssh-client=9.0_p1-r2 \
-        patch=2.7.6-r7 \
-    \
-    && npm config set unsafe-perm true \
+        nodejs=18.12.1-r0 \
+        npm=9.1.2-r0 \
+        openssh-client=9.1_p1-r1 \
+        patch=2.7.6-r8 \
     \
     && npm install \
         --no-audit \
-        --no-optional \
+        --no-fund \
         --no-update-notifier \
-        --only=production \
+        --omit=dev \
         --unsafe-perm \
     && npm rebuild --build-from-source @serialport/bindings-cpp \
     \

--- a/node-red/build.yaml
+++ b/node-red/build.yaml
@@ -1,10 +1,10 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/base:12.2.7
-  amd64: ghcr.io/hassio-addons/base:12.2.7
-  armhf: ghcr.io/hassio-addons/base:12.2.7
-  armv7: ghcr.io/hassio-addons/base:12.2.7
-  i386: ghcr.io/hassio-addons/base:12.2.7
+  aarch64: ghcr.io/hassio-addons/base:13.0.0
+  amd64: ghcr.io/hassio-addons/base:13.0.0
+  armhf: ghcr.io/hassio-addons/base:13.0.0
+  armv7: ghcr.io/hassio-addons/base:13.0.0
+  i386: ghcr.io/hassio-addons/base:13.0.0
 codenotary:
   base_image: codenotary@frenck.dev
   signer: codenotary@frenck.dev


### PR DESCRIPTION
# Proposed Changes

Upgrades the add-on base image to a new major release, which is based on Alpine Linux 3.17 and runs on NodeJS 18.