### PR TITLE
Add new themes introduced in @node-red-contrib-themes/theme-collection v3.1

### DIFF
--- a/node-red/DOCS.md
+++ b/node-red/DOCS.md
@@ -119,14 +119,24 @@ Sets one of the Node-RED themes. Currently available options:
 - `dark`
 - `dracula`
 - `espresso-libre`
+- `github-dark`
+- `github-dark-default`
+- `github-dark-dimmed`
 - `midnight-red`
 - `monoindustrial`
 - `monokai`
+- `monokai-dimmed`
+- `noctis`
 - `oceanic-next`
 - `oled`
+- `one-dark-pro`
+- `one-dark-pro-darker`
 - `solarized-dark`
 - `solarized-light`
 - `tokyo-night`
+- `tokyo-night-light`
+- `tokyo-night-storm`
+- `totallyinformation`
 - `zenburn`
 
 ### Option: `http_node`

--- a/node-red/config.yaml
+++ b/node-red/config.yaml
@@ -50,7 +50,7 @@ options:
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   credential_secret: password
-  theme: list(default|aurora|cobalt2|dark|dracula|espresso-libre|midnight-red|monoindustrial|monokai|oceanic-next|oled|solarized-dark|solarized-light|tokyo-night|zenburn)?
+  theme: list(default|aurora|cobalt2|dark|dracula|espresso-libre|github-dark|github-dark-default|github-dark-dimmed|midnight-red|monoindustrial|monokai|monokai-dimmed|noctis|oceanic-next|oled|one-dark-pro|one-dark-pro-darker|solarized-dark|solarized-light|tokyo-night|tokyo-night-light|tokyo-night-storm|totallyinformation|zenburn)?
   http_node:
     username: str
     password: password


### PR DESCRIPTION
# Proposed Changes

Node-RED Contrib Theme Collection version 3.1 introduced new themes:

- `github-dark`
- `github-dark-default`
- `github-dark-dimmed`
- `monokai-dimmed`
- `noctis`
- `one-dark-pro`
- `one-dark-pro-darker`
- `tokyo-night-light`
- `tokyo-night-storm`
- `totallyinformation`

This PR adds them to the add-on config.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
