### PR TITLE
Make credentials secret optional

### DIFF
--- a/node-red/DOCS.md
+++ b/node-red/DOCS.md
@@ -18,8 +18,6 @@ comparison to installing any other Home Assistant add-on.
    [![Open this add-on in your Home Assistant instance.][addon-badge]][addon]
 
 1. Click the "Install" button to install the add-on.
-1. Set a `credential_secret`, which is used to encrypt sensitive data.
-   This is just a "password", which you should save in a secondary location.
 1. Start the "Node-RED" add-on.
 1. Check the logs of "Node-RED" to see if everything went well.
 1. Click on the "OPEN WEB UI" button to jump into Node-RED.
@@ -36,7 +34,6 @@ Example add-on configuration:
 
 ```yaml
 log_level: info
-credential_secret: KJHhfdhiFRENCKfsdfdsDHFHDJS
 http_node:
   username: MarryPoppins
   password: Supercalifragilisticexpialidocious

--- a/node-red/config.yaml
+++ b/node-red/config.yaml
@@ -32,7 +32,6 @@ map:
   - share:rw
   - ssl
 options:
-  credential_secret: ""
   theme: default
   http_node:
     username: ""
@@ -48,7 +47,7 @@ options:
   init_commands: []
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
-  credential_secret: password
+  credential_secret: password?
   theme: list(default|aurora|cobalt2|dark|dracula|espresso-libre|github-dark|github-dark-default|github-dark-dimmed|midnight-red|monoindustrial|monokai|monokai-dimmed|noctis|oceanic-next|oled|one-dark-pro|one-dark-pro-darker|solarized-dark|solarized-light|tokyo-night|tokyo-night-light|tokyo-night-storm|totallyinformation|zenburn)?
   http_node:
     username: str

--- a/node-red/rootfs/etc/node-red/config.js
+++ b/node-red/rootfs/etc/node-red/config.js
@@ -26,8 +26,10 @@ config.adminAuth = null;
 // Disable SSL, since the add-on handles that
 config.https = null;
 
-// Several settings
-config.credentialSecret = options.credential_secret;
+// Credential secret
+if (options.credentialSecret) {
+  config.credentialSecret = options.credential_secret;
+}
 
 // Secure HTTP node
 if (options.http_node.username) {

--- a/node-red/rootfs/etc/s6-overlay/s6-rc.d/init-nodered/run
+++ b/node-red/rootfs/etc/s6-overlay/s6-rc.d/init-nodered/run
@@ -6,24 +6,6 @@
 # ==============================================================================
 declare port
 
-# Ensure the credential secret value is set
-if bashio::config.is_empty 'credential_secret'; then
-    bashio::log.fatal
-    bashio::log.fatal 'Configuration of this add-on is incomplete.'
-    bashio::log.fatal
-    bashio::log.fatal 'Please be sure to set the "credential_secret" option.'
-    bashio::log.fatal
-    bashio::log.fatal 'The credential secret is an encryption token, much like'
-    bashio::log.fatal 'a password, that is used by Node-RED for encrypting'
-    bashio::log.fatal 'credentials you put into Node-RED.'
-    bashio::log.fatal
-    bashio::log.fatal 'Just like a password, a credential secret can be'
-    bashio::log.fatal 'anything you like. Just be sure to store it somewhere'
-    bashio::log.fatal 'safe for later, e.g., in case of a recovery.'
-    bashio::log.fatal
-    bashio::exit.nok
-fi
-
 # Migrate add-on data from the Home Assistant config folder,
 # to the add-on configuration folder.
 if ! bashio::fs.directory_exists '/config/settings.js' \


### PR DESCRIPTION
# Proposed Changes

This PR makes the credential secret optional. While a user should set this, really... and while it is documented, people rather bitch about it as they cannot hit start after install. Easiness is more important than security.

closes #1716 

../Frenck