### PR TITLE
🚨 Drop support for ARMv7

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ SOFTWARE.
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
 [armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
+[armv7-shield]: https://img.shields.io/badge/armv7-no-red.svg
 [bonanitech]: https://github.com/bonanitech
 [commits-shield]: https://img.shields.io/github/commit-activity/y/hassio-addons/addon-node-red.svg
 [commits]: https://github.com/hassio-addons/addon-node-red/commits/master

--- a/node-red/build.yaml
+++ b/node-red/build.yaml
@@ -2,7 +2,6 @@
 build_from:
   aarch64: ghcr.io/hassio-addons/base-nodejs:0.2.5
   amd64: ghcr.io/hassio-addons/base-nodejs:0.2.5
-  armv7: ghcr.io/hassio-addons/base-nodejs:0.2.5
 codenotary:
   base_image: codenotary@frenck.dev
   signer: codenotary@frenck.dev

--- a/node-red/config.yaml
+++ b/node-red/config.yaml
@@ -14,7 +14,6 @@ homeassistant: 2023.3.0
 arch:
   - aarch64
   - amd64
-  - armv7
 ports:
   80/tcp: 1880
 ports_description:


### PR DESCRIPTION
# Proposed Changes

SSIA, this PR drops support for ARMv7 (from several add-ons). I do not see an way out at this point.

Refs:
- https://gitlab.com/qemu-project/qemu/-/issues/1729
- https://github.com/nodejs/docker-node/issues/1798
- https://github.com/nodejs/docker-node/issues/1829
- https://github.com/tonistiigi/binfmt/pull/185





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Architecture Support**
	- Removed support for `armv7` architecture
	- Now supports only `aarch64` and `amd64` architectures

- **Documentation**
	- Updated README.md to reflect architecture support changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->