### PR TITLE
Disable proxy buffering

### DIFF
--- a/node-red/rootfs/etc/nginx/includes/proxy_params.conf
+++ b/node-red/rootfs/etc/nginx/includes/proxy_params.conf
@@ -4,6 +4,7 @@ proxy_read_timeout          86400s;
 proxy_redirect              off;
 proxy_send_timeout          86400s;
 proxy_max_temp_file_size    0;
+proxy_buffering             off;
 
 proxy_set_header Accept-Encoding "";
 proxy_set_header Connection $connection_upgrade;


### PR DESCRIPTION
# Proposed Changes

Disables proxy buffering in nginx to aid with possible interference when receiving large WebSocket frames.

Ref: https://github.com/hassio-addons/addon-node-red/issues/1986