### PR TITLE
Clarify timezone handling

### DIFF
--- a/node-red/DOCS.md
+++ b/node-red/DOCS.md
@@ -209,9 +209,12 @@ configuration folder, including the `flows.json`.
 
 ## Time zone configuration
 
-The addon will use the configured time zone of the underlying operating system.
-If this is incorrect (for example with the Home Assistant Operating System it
-will be UTC), this can be configured in the `settings.js` file.
+The add-on will use the time zone configured in Home Assistant settings. If
+the timezone is incorrect, update the setting in Home Assistant and restart
+the Node-RED add-on to apply the latest configuration.
+
+If you would like to override the time zone for Node RED specifically, this
+can be configured in the `settings.js` file.
 
 To do so, open the file with a text editor and add the following above the
 `module.exports = {` line.

--- a/node-red/DOCS.md
+++ b/node-red/DOCS.md
@@ -210,7 +210,7 @@ configuration folder, including the `flows.json`.
 ## Time zone configuration
 
 The add-on will use the time zone configured in Home Assistant settings. If
-the timezone is incorrect, update the setting in Home Assistant and restart
+the time zone is incorrect, update the setting in Home Assistant and restart
 the Node-RED add-on to apply the latest configuration.
 
 If you would like to override the time zone for Node RED specifically, this

--- a/node-red/DOCS.md
+++ b/node-red/DOCS.md
@@ -213,7 +213,7 @@ The add-on will use the time zone configured in Home Assistant settings. If
 the time zone is incorrect, update the setting in Home Assistant and restart
 the Node-RED add-on to apply the latest configuration.
 
-If you would like to override the time zone for Node RED specifically, this
+If you would like to override the time zone for Node-RED specifically, this
 can be configured in the `settings.js` file.
 
 To do so, open the file with a text editor and add the following above the


### PR DESCRIPTION
# Proposed Changes
Today, time zone is not inherited from the underlying operating system. Supervisor passes the `TZ` environment variable according to its configuration. By default the Home Assistant setting is passed to Supervisor.

## Related Issues

This came up during discussion at https://github.com/home-assistant/supervisor/issues/5811.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified instructions on configuring the time zone for the Node-RED add-on, specifying that it uses the Home Assistant time zone setting and providing guidance on updating and overriding the time zone.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->