### PR TITLE
Add new themes introduced in @node-red-contrib-themes/theme-collection v4.1

### DIFF
--- a/node-red/DOCS.md
+++ b/node-red/DOCS.md
@@ -123,11 +123,22 @@ Sets one of the Node-RED themes. Currently available options:
 - `monoindustrial`
 - `monokai`
 - `monokai-dimmed`
+- `night-owl`
 - `noctis`
+- `noctis-azureus`
+- `noctis-bordo`
+- `noctis-minimus`
+- `noctis-obscuro`
+- `noctis-sereno`
+- `noctis-uva`
+- `noctis-viola`
 - `oceanic-next`
 - `oled`
 - `one-dark-pro`
 - `one-dark-pro-darker`
+- `railscasts-extended`
+- `selenized-dark`
+- `selenized-light`
 - `solarized-dark`
 - `solarized-light`
 - `tokyo-night`
@@ -135,6 +146,7 @@ Sets one of the Node-RED themes. Currently available options:
 - `tokyo-night-storm`
 - `totallyinformation`
 - `zenburn`
+- `zendesk-garden`
 
 ### Option: `http_node`
 

--- a/node-red/config.yaml
+++ b/node-red/config.yaml
@@ -49,7 +49,7 @@ options:
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   credential_secret: password?
-  theme: list(default|aurora|cobalt2|dark|dracula|espresso-libre|github-dark|github-dark-default|github-dark-dimmed|midnight-red|monoindustrial|monokai|monokai-dimmed|noctis|oceanic-next|oled|one-dark-pro|one-dark-pro-darker|solarized-dark|solarized-light|tokyo-night|tokyo-night-light|tokyo-night-storm|totallyinformation|zenburn)?
+  theme: list(default|aurora|cobalt2|dark|dracula|espresso-libre|github-dark|github-dark-default|github-dark-dimmed|midnight-red|monoindustrial|monokai|monokai-dimmed|night-owl|noctis|noctis-azureus|noctis-bordo|noctis-minimus|noctis-obscuro|noctis-sereno|noctis-uva|noctis-viola|oceanic-next|oled|one-dark-pro|one-dark-pro-darker|railscasts-extended|selenized-dark|selenized-light|solarized-dark|solarized-light|tokyo-night|tokyo-night-light|tokyo-night-storm|totallyinformation|zenburn|zendesk-garden)?
   http_node:
     username: str
     password: password


### PR DESCRIPTION
# Proposed Changes

Node-RED Contrib Theme Collection version 4.1 introduced new themes:

- night-owl
- noctis-azureus
- noctis-bordo
- noctis-minimus
- noctis-obscuro
- noctis-sereno
- noctis-uva
- noctis-viola
- railscasts-extended
- selenized-dark
- selenized-light
- zendesk-garden

This PR adds them to the add-on config.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the selection of available themes for Node-RED with several new options, including additional "noctis" variants, "night-owl," "railscasts-extended," "selenized-dark," "selenized-light," and "zendesk-garden."
* **Documentation**
  * Updated documentation to reflect the newly added theme options in the configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->