### PR TITLE
Clean up older architecture references

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,7 @@
       "matchStringsStrategy": "any",
       "matchStrings": [
         "ARG BUILD_FROM=(?<depName>.*?):(?<currentValue>.*?)\\s+",
-        "(aarch64|amd64|armhf|armv7|i386):\\s[\"']?(?<depName>.*?):(?<currentValue>.*?)[\"']?\\s"
+        "(aarch64|amd64):\\s[\"']?(?<depName>.*?):(?<currentValue>.*?)[\"']?\\s"
       ],
       "datasourceTemplate": "docker"
     },

--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@
 
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
-![Supports armhf Architecture][armhf-shield]
-![Supports armv7 Architecture][armv7-shield]
-![Supports i386 Architecture][i386-shield]
 
 [![Github Actions][github-actions-shield]][github-actions]
 ![Project Maintenance][maintenance-shield]
@@ -102,8 +99,6 @@ SOFTWARE.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-no-red.svg
 [bonanitech]: https://github.com/bonanitech
 [commits-shield]: https://img.shields.io/github/commit-activity/y/hassio-addons/addon-node-red.svg
 [commits]: https://github.com/hassio-addons/addon-node-red/commits/master
@@ -119,7 +114,6 @@ SOFTWARE.
 [github-actions]: https://github.com/hassio-addons/addon-node-red/actions
 [github-sponsors-shield]: https://frenck.dev/wp-content/uploads/2019/12/github_sponsor.png
 [github-sponsors]: https://github.com/sponsors/frenck
-[i386-shield]: https://img.shields.io/badge/i386-no-red.svg
 [issue]: https://github.com/hassio-addons/addon-node-red/issues
 [license-shield]: https://img.shields.io/github/license/hassio-addons/addon-node-red.svg
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2025.svg


### PR DESCRIPTION
# Proposed Changes

Cleaning up some deprecated (and unused) architectures by this add-on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed support for armhf, armv7, and i386 architectures. Updated build configuration and documentation to reflect aarch64 and amd64 support only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->