### PR TITLE
Update deprecated http2 nginx conf syntax

### DIFF
--- a/node-red/rootfs/etc/nginx/templates/direct.gtpl
+++ b/node-red/rootfs/etc/nginx/templates/direct.gtpl
@@ -2,7 +2,8 @@ server {
     {{ if not .ssl }}
     listen {{ .port }} default_server;
     {{ else }}
-    listen {{ .port }} default_server ssl http2;
+    listen {{ .port }} default_server ssl;
+    http2 on;
     {{ end }}
 
     include /etc/nginx/includes/server_params.conf;


### PR DESCRIPTION
# Proposed Changes

This PR changes the [direct.gtpl](https://github.com/hassio-addons/addon-node-red/tree/main/node-red/rootfs/etc/nginx/templates/direct.gtpl) file to separate `http2` from the `listen ...` line to a separate line `http2 on;` 

Will get rid of the `the "listen ... http2" directive is deprecated, use the "http2" directive instead in /etc/nginx/servers/direct.conf:3` warning in the logs.

## Related Issues

#2172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nginx SSL configuration structure for improved HTTP/2 handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->