### PR TITLE
Rename 'dark' theme to 'dark-modern'

### DIFF
--- a/node-red/DOCS.md
+++ b/node-red/DOCS.md
@@ -113,7 +113,7 @@ Sets one of the Node-RED themes. Currently available options:
 - `default`
 - `aurora`
 - `cobalt2`
-- `dark`
+- `dark-modern`
 - `dracula`
 - `espresso-libre`
 - `github-dark`

--- a/node-red/config.yaml
+++ b/node-red/config.yaml
@@ -48,7 +48,7 @@ options:
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   credential_secret: password?
-  theme: list(default|aurora|cobalt2|dark-modern|dracula|espresso-libre|github-dark|github-dark-default|github-dark-dimmed|midnight-red|monoindustrial|monokai|monokai-dimmed|night-owl|noctis|noctis-azureus|noctis-bordo|noctis-minimus|noctis-obscuro|noctis-sereno|noctis-uva|noctis-viola|oceanic-next|oled|one-dark-pro|one-dark-pro-darker|railscasts-extended|selenized-dark|selenized-light|solarized-dark|solarized-light|tokyo-night|tokyo-night-light|tokyo-night-storm|totallyinformation|zenburn|zendesk-garden)?
+  theme: list(default|aurora|cobalt2|dark|dark-modern|dracula|espresso-libre|github-dark|github-dark-default|github-dark-dimmed|midnight-red|monoindustrial|monokai|monokai-dimmed|night-owl|noctis|noctis-azureus|noctis-bordo|noctis-minimus|noctis-obscuro|noctis-sereno|noctis-uva|noctis-viola|oceanic-next|oled|one-dark-pro|one-dark-pro-darker|railscasts-extended|selenized-dark|selenized-light|solarized-dark|solarized-light|tokyo-night|tokyo-night-light|tokyo-night-storm|totallyinformation|zenburn|zendesk-garden)?
   http_node:
     username: str
     password: password

--- a/node-red/config.yaml
+++ b/node-red/config.yaml
@@ -48,7 +48,7 @@ options:
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   credential_secret: password?
-  theme: list(default|aurora|cobalt2|dark|dracula|espresso-libre|github-dark|github-dark-default|github-dark-dimmed|midnight-red|monoindustrial|monokai|monokai-dimmed|night-owl|noctis|noctis-azureus|noctis-bordo|noctis-minimus|noctis-obscuro|noctis-sereno|noctis-uva|noctis-viola|oceanic-next|oled|one-dark-pro|one-dark-pro-darker|railscasts-extended|selenized-dark|selenized-light|solarized-dark|solarized-light|tokyo-night|tokyo-night-light|tokyo-night-storm|totallyinformation|zenburn|zendesk-garden)?
+  theme: list(default|aurora|cobalt2|dark-modern|dracula|espresso-libre|github-dark|github-dark-default|github-dark-dimmed|midnight-red|monoindustrial|monokai|monokai-dimmed|night-owl|noctis|noctis-azureus|noctis-bordo|noctis-minimus|noctis-obscuro|noctis-sereno|noctis-uva|noctis-viola|oceanic-next|oled|one-dark-pro|one-dark-pro-darker|railscasts-extended|selenized-dark|selenized-light|solarized-dark|solarized-light|tokyo-night|tokyo-night-light|tokyo-night-storm|totallyinformation|zenburn|zendesk-garden)?
   http_node:
     username: str
     password: password

--- a/node-red/rootfs/etc/node-red/config.js
+++ b/node-red/rootfs/etc/node-red/config.js
@@ -5,7 +5,10 @@ const bcrypt = require("bcryptjs");
 
 if ("theme" in options) {
   if (options.theme !== "default") {
-    config.editorTheme.theme = options.theme;
+    // The "dark" theme was renamed to "dark-modern" in theme-collection v5.
+    // Keep applying the correct theme when the deprecated value is still set.
+    config.editorTheme.theme =
+      options.theme === "dark" ? "dark-modern" : options.theme;
   }
 }
 

--- a/node-red/rootfs/etc/s6-overlay/s6-rc.d/init-nodered/run
+++ b/node-red/rootfs/etc/s6-overlay/s6-rc.d/init-nodered/run
@@ -29,6 +29,15 @@ if ! bashio::fs.file_exists '/config/settings.js'; then
     sed -i "s/%%ID%%/${id}/" "/config/flows.json"
 fi
 
+# The "dark" theme was renamed to "dark-modern" in theme-collection v5.
+# Migrate the stored option so it stays valid and shows the new value.
+if bashio::config.equals 'theme' 'dark'; then
+    bashio::log.notice "Migrating deprecated 'dark' theme to 'dark-modern'..."
+    bashio::app.option 'theme' 'dark-modern' \
+        || bashio::log.warning \
+            "Could not migrate the 'theme' option, continuing anyway..."
+fi
+
 # Pass in port & SSL settings
 port=$(bashio::app.port 80)
 sed -i "s/%%PORT%%/${port:-80}/" "/opt/node_modules/node-red-dashboard/nodes/ui_base.html"


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

The 'dark' theme has been renamed to 'dark-modern' to avoid confusion with the dark mode introduced in Node-RED v5.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded available Node-RED theme options with new variants including dark-modern, noctis-*, monoindustrial, and additional selections.

* **Bug Fixes**
  * Automatic migration of the deprecated "dark" dashboard theme to "dark-modern" with a logged notice if migration encounters issues.

* **Documentation**
  * Updated docs to reflect the expanded list of supported themes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->