### PR TITLE
🐛 Use bashio::app functions for bashio v0.18 compatibility

### DIFF
--- a/node-red/rootfs/etc/s6-overlay/s6-rc.d/init-nginx/run
+++ b/node-red/rootfs/etc/s6-overlay/s6-rc.d/init-nginx/run
@@ -8,14 +8,14 @@ declare admin_port
 
 # Generate Ingress configuration
 bashio::var.json \
-    interface "$(bashio::addon.ip_address)" \
-    port "^$(bashio::addon.ingress_port)" \
+    interface "$(bashio::app.ip_address)" \
+    port "^$(bashio::app.ingress_port)" \
     | tempio \
         -template /etc/nginx/templates/ingress.gtpl \
         -out /etc/nginx/servers/ingress.conf
 
 # Generate direct access configuration, if enabled.
-admin_port=$(bashio::addon.port 80)
+admin_port=$(bashio::app.port 80)
 if bashio::var.has_value "${admin_port}"; then
     bashio::config.require.ssl
     bashio::var.json \

--- a/node-red/rootfs/etc/s6-overlay/s6-rc.d/init-nodered/run
+++ b/node-red/rootfs/etc/s6-overlay/s6-rc.d/init-nodered/run
@@ -30,7 +30,7 @@ if ! bashio::fs.file_exists '/config/settings.js'; then
 fi
 
 # Pass in port & SSL settings
-port=$(bashio::addon.port 80)
+port=$(bashio::app.port 80)
 sed -i "s/%%PORT%%/${port:-80}/" "/opt/node_modules/node-red-dashboard/nodes/ui_base.html"
 if ! bashio::var.has_value "${port}"; then
     bashio::log.warning


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

bashio was upgraded from v0.17.5 to v0.18.1, which now ships in the base image since the v21.0.0 bump (#2225, already merged to `main`).

In bashio v0.18, the `addon.sh` library was renamed to `apps.sh` and the `bashio::addon.*` functions were removed in favor of `bashio::app.*` (see [hassio-addons/bashio](https://github.com/hassio-addons/bashio)). Because there are no backwards-compatible aliases, the existing `bashio::addon.*` calls in our init scripts now fail at runtime on the new base image.

This updates the NGINX and Node-RED init scripts to use the new function names:

- `bashio::addon.ip_address` → `bashio::app.ip_address`
- `bashio::addon.ingress_port` → `bashio::app.ingress_port`
- `bashio::addon.port` → `bashio::app.port`

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Follow-up to #2225, which moved the app to base image v21.0.0 (bashio v0.18.1).

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated network configuration sourcing for ingress and direct access functionality to ensure proper port handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->