### PR TITLE
🔧 Align engines.node with Node-RED 5 requirement

### DIFF
--- a/node-red/package.json
+++ b/node-red/package.json
@@ -39,6 +39,6 @@
     "source-map-support": "0.5.21"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18.5"
   }
 }


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

The `engines.node` constraint in `package.json` still declared `>=16`, which no longer reflects reality: Node-RED 5 (merged in #2227) requires Node.js `>=18.5`, and the base image now ships Node.js 24. This bumps the declared engine to `>=18.5` to match Node-RED 5's own requirement.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Node.js version requirement from 16 to 18.5 or higher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->