### PR TITLE
🔧 Use npm --omit flags instead of deprecated install flags

### DIFF
--- a/node-red/rootfs/etc/s6-overlay/s6-rc.d/init-customizations/run
+++ b/node-red/rootfs/etc/s6-overlay/s6-rc.d/init-customizations/run
@@ -28,8 +28,8 @@ if bashio::config.has_value 'npm_packages'; then
     done
 
     npm install \
-        --no-optional \
-        --only=production \
+        --omit=dev \
+        --omit=optional \
         "${npmlist[@]}" \
            || bashio::exit.nok "Failed to install a specified npm package"
 fi


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

The custom-package installer used the long-deprecated npm flags `--no-optional` and `--only=production`. These were deprecated back in npm 7, and the base image now ships npm 11, which emits deprecation warnings for them.

This replaces them with the modern `--omit` equivalents:

- `--no-optional` → `--omit=optional`
- `--only=production` → `--omit=dev`

This also matches the flags already used in the `Dockerfile`, which installs the bundled packages with `--omit=dev`.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node-RED package installation configuration to more efficiently manage dependencies during setup, ensuring only necessary packages are installed while reducing installation overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->