### PR TITLE
🔧 Add missing shellcheck directive to NGINX s6 scripts

### DIFF
--- a/node-red/rootfs/etc/s6-overlay/s6-rc.d/nginx/finish
+++ b/node-red/rootfs/etc/s6-overlay/s6-rc.d/nginx/finish
@@ -1,4 +1,5 @@
 #!/command/with-contenv bashio
+# shellcheck shell=bash
 # ==============================================================================
 # Home Assistant Community App: Node-RED
 # Take down the S6 supervision tree when Nginx fails

--- a/node-red/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
+++ b/node-red/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
@@ -1,4 +1,5 @@
 #!/command/with-contenv bashio
+# shellcheck shell=bash
 # ==============================================================================
 # Home Assistant Community App: Node-RED
 # Runs the Nginx daemon


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Every s6 `run`/`finish` script in this app carries a `# shellcheck shell=bash` directive so ShellCheck knows how to lint them, except for the two NGINX scripts. This adds the missing directive to `nginx/run` and `nginx/finish` for consistency and proper linting.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code quality standards for internal build and deployment scripts through improved static analysis configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->