### PR TITLE
🔧 Drop redundant $NODE_OPTIONS token from start script

### DIFF
--- a/node-red/package.json
+++ b/node-red/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "node_modules/node-red/red/red.js",
   "scripts": {
-    "start": "node $NODE_OPTIONS node_modules/node-red/red.js"
+    "start": "node node_modules/node-red/red.js"
   },
   "dependencies": {
     "bcryptjs": "3.0.3",


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

The `start` script passed `$NODE_OPTIONS` as a command-line token: `node $NODE_OPTIONS node_modules/node-red/red.js`. That is redundant and fragile, since Node.js already reads and applies the `NODE_OPTIONS` environment variable automatically. When `max_old_space_size` is configured, the s6 `nodered/run` service exports `NODE_OPTIONS`, so Node picks it up from the environment regardless; expanding it again on the command line just duplicated the flag.

This drops the redundant `$NODE_OPTIONS` token from the script. Behaviour is unchanged: `NODE_OPTIONS` is still honoured via the environment.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
