### PR TITLE
🔥 Remove unmaintained node-red-node-twitter package

### DIFF
--- a/node-red/package.json
+++ b/node-red/package.json
@@ -33,7 +33,6 @@
     "node-red-node-serialport": "2.0.3",
     "node-red-node-smooth": "0.1.2",
     "node-red-node-suncalc": "1.2.0",
-    "node-red-node-twitter": "1.2.0",
     "@node-red-contrib-themes/theme-collection": "5.0.1",
     "line-by-line": "0.1.6",
     "source-map-support": "0.5.21"


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

`node-red-node-twitter` has been unmaintained for years (the package is flagged "No longer maintained" upstream), and the Twitter/X API it relies on is no longer usable for the free/legacy access this node was built around. Keeping it in the bundled set only adds a dead dependency and a deprecation warning on every build.

This removes `node-red-node-twitter` from the bundled packages. Users who still need it can install it themselves through the `npm_packages` option.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
