### PR TITLE
📝 Fix broken branch links and typos in README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You have several options to get them answered:
 - Join the [Reddit subreddit][reddit] in [/r/homeassistant][reddit]
 - The [Node-RED documentation][nodered-docs]
 
-You could also [open an issue here][issue] GitHub.
+You could also [open an issue here][issue] on GitHub.
 
 ## Contributing
 
@@ -93,11 +93,11 @@ SOFTWARE.
 
 [bonanitech]: https://github.com/bonanitech
 [commits-shield]: https://img.shields.io/github/commit-activity/y/hassio-addons/app-node-red.svg
-[commits]: https://github.com/hassio-addons/app-node-red/commits/master
+[commits]: https://github.com/hassio-addons/app-node-red/commits/main
 [contributors]: https://github.com/hassio-addons/app-node-red/graphs/contributors
 [discord-ha]: https://discord.gg/c5DvZ4e
 [discord]: https://discord.me/hassioaddons
-[docs]: https://github.com/hassio-addons/app-node-red/blob/master/node-red/DOCS.md
+[docs]: https://github.com/hassio-addons/app-node-red/blob/main/node-red/DOCS.md
 [forum]: https://community.home-assistant.io/t/home-assistant-community-add-on-node-red/55023?u=frenck
 [frenck]: https://github.com/frenck
 [github-actions-shield]: https://github.com/hassio-addons/app-node-red/workflows/CI/badge.svg

--- a/node-red/DOCS.md
+++ b/node-red/DOCS.md
@@ -104,7 +104,7 @@ Node-RED from being able to decrypt your existing credentials and they will be
 lost._
 
 **Note**: _If you have manually enabled the use of project in Node-RED, this
-option will, eventhough required, be ignored by Node-RED._
+option will, even though required, be ignored by Node-RED._
 
 ### Option: `theme`
 
@@ -172,7 +172,7 @@ properties can be used:
 ### Option: `system_packages`
 
 Allows you to specify additional [Alpine packages][alpine-packages] to be
-installed to your Node-RED setup (e.g., `g++`. `make`, `ffmpeg`).
+installed to your Node-RED setup (e.g., `g++`, `make`, `ffmpeg`).
 
 **Note**: _Adding many packages will result in a longer start-up time
 for the app._
@@ -194,7 +194,7 @@ single time this app starts.
 
 ### Option: `safe_mode`
 
-Setting this option to `true` will start Node-Red with the `--safe` flag set,
+Setting this option to `true` will start Node-RED with the `--safe` flag set,
 starting the application without starting any flows for troubleshooting.
 
 ### Option: `leave_front_door_open`
@@ -248,7 +248,7 @@ Save the file and restart the Node-RED app.
   "Network" configuration section of the app.
 
 - If you cannot access HTTP nodes or Node-RED Dashboard, please check
-  if you URL starts with `/endpoint/`, or else Home Assistant authentication
+  if your URL starts with `/endpoint/`, or else Home Assistant authentication
   will kick in.
 
 - If the following error is seen after an update:
@@ -286,7 +286,7 @@ You have several options to get them answered:
 - Join the [Reddit subreddit][reddit] in [/r/homeassistant][reddit]
 - The [Node-RED documentation][nodered-docs]
 
-You could also [open an issue here][issue] GitHub.
+You could also [open an issue here][issue] on GitHub.
 
 ## Authors & contributors
 


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Small documentation cleanup of the README and DOCS pages:

- Point the `[commits]` and `[docs]` links in the README to the `main` branch. They still referenced `master`, which no longer exists, so those links were broken (the "Read the full app documentation" link being the user-facing one).
- Fix a few typos in the docs:
  - `g++`. → `g++`, in the `system_packages` example
  - "eventhough" → "even though"
  - "if you URL" → "if your URL"
  - "Node-Red" → "Node-RED"
- Reword "open an issue here GitHub" → "open an issue here on GitHub" (README and DOCS).

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed typos, punctuation, and formatting inconsistencies across README and project documentation files
  * Updated repository reference links from legacy branch to main branch
  * Standardized product naming conventions and casing throughout documentation
  * Corrected spacing and added missing punctuation in documentation links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->