### PR TITLE
✨ Listen on IPv6 for direct access

### DIFF
--- a/node-red/rootfs/etc/nginx/templates/direct.gtpl
+++ b/node-red/rootfs/etc/nginx/templates/direct.gtpl
@@ -1,8 +1,10 @@
 server {
     {{ if not .ssl }}
     listen {{ .port }} default_server;
+    listen [::]:{{ .port }} default_server;
     {{ else }}
     listen {{ .port }} default_server ssl;
+    listen [::]:{{ .port }} default_server ssl;
     http2 on;
     {{ end }}
 


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

The direct-access NGINX server only listened on IPv4 (`listen {{ .port }};`), so Node-RED was unreachable over IPv6. This is a real problem for users whose ISP uses DS-Lite/CGNAT and can only be reached from the outside over IPv6.

This adds IPv6 `listen [::]:{{ .port }}` directives to the direct-access server template, for both the plain and SSL variants. NGINX defaults to `ipv6only=on` for the `[::]` socket, so the IPv4 and IPv6 listeners coexist without conflict.

Ingress is intentionally untouched (it binds the Supervisor's internal IPv4 interface), and Node-RED itself keeps listening on `127.0.0.1` behind NGINX, so only the externally exposed direct-access vhost needed the change.

Validated by rendering the template with `tempio` for both the SSL and non-SSL cases and running `nginx -t` against the result.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Closes #1192

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
